### PR TITLE
feat(telescope): allow customization of bindings; use prompt text for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This is a very minimalist note-taking plugin for Neovim. It provides functionali
     config = function ()
         require('simple-note').setup({
             notes_dir = '~/my-notes/' -- default: '~/notes/'
+            telescope_new = "<C-n>",
+            telescope_delete = "<C-x>",
+            telescope_rename = "<C-r>",
         })
     end
 }
@@ -35,9 +38,9 @@ This is a very minimalist note-taking plugin for Neovim. It provides functionali
 - `:SimpleNoteList`: Lists all existing notes in a Telescope prompt.
 - `:SimpleNoteCreate [filename (optional)]`: Creates a new note file and opens it in Neovim.
 
-### Telescope prompt keymaps
+### Telescope default prompt keymaps
 
-- `<c-n>`: Creates new note
+- `<c-n>`: Creates new note (using the current line in the search prompt if any)
 - `<c-x>`: Delete note
 - `<c-r>`: Rename note
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ This is a very minimalist note-taking plugin for Neovim. It provides functionali
     },
     config = function ()
         require('simple-note').setup({
-            notes_dir = '~/my-notes/' -- default: '~/notes/'
-            telescope_new = "<C-n>",
-            telescope_delete = "<C-x>",
-            telescope_rename = "<C-r>",
+            notes_dir = '~/my-notes/', -- default: '~/notes/'
+            telescope_new = '<C-n>',
+            telescope_delete = '<C-x>',
+            telescope_rename = '<C-r>',
         })
     end
 }

--- a/doc/simple-note.txt
+++ b/doc/simple-note.txt
@@ -37,10 +37,10 @@ Use the following configuration in your init.vim or init.lua file:
     },
     config = function ()
         require('simple-note').setup({
-            notes_dir = '~/my-notes/' -- default: '~/notes/'
-            telescope_new = "<C-n>",
-            telescope_delete = "<C-x>",
-            telescope_rename = "<C-r>",
+            notes_dir = '~/my-notes/', -- default: '~/notes/'
+            telescope_new = '<C-n>',
+            telescope_delete = '<C-x>',
+            telescope_rename = '<C-r>',
         })
     end
 }

--- a/doc/simple-note.txt
+++ b/doc/simple-note.txt
@@ -1,4 +1,4 @@
-*simple-note.txt* For Neovim version 0.8. Last change: 2024 Jan 27 
+*simple-note.txt* For Neovim version 0.8. Last change: 2024 Jan 29
 
 ==============================================================================
 CONTENTS                                                       *simple-note*
@@ -12,7 +12,7 @@ CONTENTS                                                       *simple-note*
 ==============================================================================
 INTRODUCTION                                             *simple-note-introduction*
 
-This is a very minimalist note-taking plugin for Neovim. It provides 
+This is a very minimalist note-taking plugin for Neovim. It provides
 functionality to create, list, preview, rename, and delete notes.
 
 ==============================================================================
@@ -38,6 +38,9 @@ Use the following configuration in your init.vim or init.lua file:
     config = function ()
         require('simple-note').setup({
             notes_dir = '~/my-notes/' -- default: '~/notes/'
+            telescope_new = "<C-n>",
+            telescope_delete = "<C-x>",
+            telescope_rename = "<C-r>",
         })
     end
 }
@@ -53,14 +56,15 @@ Commands:
 
 Telescope prompt keymaps:
 
-- `<c-n>`: Creates new note
+- `<c-n>`: Creates new note (using the current line in the search prompt if
+  any)
 - `<c-x>`: Delete note
 - `<c-r>`: Rename note
 
 ==============================================================================
 LICENSE                                                  *simple-note-license*
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) 
+This project is licensed under the MIT License - see the [LICENSE](LICENSE)
 file for details.
 
 ==============================================================================


### PR DESCRIPTION
… file creation.

Since https://github.com/nvim-telescope/telescope.nvim/commit/24778fd72fcf39a0b1a6f7c6f4c4e01fef6359a2, there is a default mapping to `<C-r>`, so it will clash with this plugin. I left it as is for default keybinding, but added possibility of customize it.

Also, when user write text on search prompt and hit `<C-n>` (or provided mapping), it will use that text for the note filename.