### PR TITLE
SimpleNoteList command works in Windows

### DIFF
--- a/lua/simple-note.lua
+++ b/lua/simple-note.lua
@@ -28,11 +28,16 @@ M.listNotes = function()
   local actions = require("telescope.actions")
   local actions_state = require("telescope.actions.state")
   local finders = require("telescope.finders")
-  local find_command = { "find", ".", "-maxdepth", "1", "-not", "-type", "d" }
 
   M.picker = require("telescope.builtin").find_files({
     cwd = M.config.notes_dir,
-    find_command = find_command,
+    find_command = function()
+      if vim.fn.has "win32" == 1 then
+        return { "cmd", "/c", "dir", "/b", "/a:-d" }
+      else
+        return { "find", ".", "-maxdepth", "1", "-not", "-type", "d" }
+      end
+    end,
     layout_strategy = "flex",
     prompt_title = "Find Notes (" .. M.config.notes_dir .. ")",
     results_title = "Notes",


### PR DESCRIPTION
First, I would like to thank you for excellent and simple plugin for managing notes!

I do use neovim in Windows OS either. Windows [find command](https://www.computerhope.com/findhlp.htm) has absolutely different syntax and goal.
So I decided to make the tiny PR to add Windows support.
I have used the functionality in my fork for one week and it seems to work good.